### PR TITLE
Reformat readme to improve context for screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,24 @@
 # Introduction
-[Yazi](https://yazi-rs.github.io/) users making use of the [dropping to the shell](https://yazi-rs.github.io/docs/tips/#dropping-to-shell) tip may want to display an indicator to easily know they're inside a yazi subshell. The following are simple instructions needed to accomplish that.
-If your shell theme is not listed below and requires specific instructions to work, feel free to submit a PR!
 
-# Instructions
-## Bash
+[Yazi](https://yazi-rs.github.io/) users making use of the [dropping to the shell](https://yazi-rs.github.io/docs/tips/#dropping-to-shell)
+tip may want to display an indicator to easily know they're inside a yazi
+subshell. The following are simple instructions needed to accomplish that. If
+your shell theme is not listed below and requires specific instructions to work,
+feel free to submit a PR!
+
+## Instructions
+
+### Bash
+
 <details>
-<summary>Default prompt</summary>
+  <summary>Default prompt</summary>
+
+  <details>
+    <summary>Screenshot</summary>
+
+![bash](https://github.com/Sonico98/yazi-prompt.sh/assets/61394886/05f8c124-c428-4b12-ac04-a4da98bbe06a)
+
+  </details>
 
 Copy and paste this into a terminal:
 
@@ -18,11 +31,20 @@ rm -rf ./yazi-prompt
 ```
 
 Then open a new shell or run `source ~/.bashrc`.
+
 </details>
 
-##  Zsh
+### Zsh
+
 <details>
-<summary>Default prompt</summary>
+  <summary>Default prompt</summary>
+
+  <details>
+    <summary>Screenshot</summary>
+
+![zsh](https://github.com/Sonico98/yazi-prompt.sh/assets/61394886/a2f693c7-3c82-4294-ac26-665def2e4a54)
+
+  </details>
 
 Copy and paste this into a terminal:
 
@@ -35,12 +57,21 @@ rm -rf ./yazi-prompt
 ```
 
 Then open a new shell or run `source "$ZDOTDIR"/.zshrc`.
+
 </details>
 
 <details>
-<summary>Powerlevel10k</summary>
+  <summary>Powerlevel10k</summary>
 
-If using [powerlevel10k](https://github.com/romkatv/powerlevel10k), copy and paste this into a terminal:
+  <details>
+    <summary>Screenshot</summary>
+
+![p10k](https://github.com/Sonico98/yazi-prompt.sh/assets/61394886/650b977f-d215-4b93-957c-191a4313a897)
+
+  </details>
+
+If using [powerlevel10k](https://github.com/romkatv/powerlevel10k), copy and
+paste this into a terminal:
 
 ```sh
 git clone https://github.com/Sonico98/yazi-prompt.sh ./yazi-prompt && \
@@ -50,45 +81,68 @@ sed 's/  # If p10k is already loaded, reload configuration./  source "$ZDOTDIR"\
 rm -rf ./yazi-prompt
 ```
 
-Then add `yazi` to `POWERLEVEL9K_LEFT_PROMPT_ELEMENTS` or `POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS`, near the top of ~/.p10k.zsh, and open a new shell.
-You can modify the color by editing $ZDOTDIR/.yazi_p10k.zsh
+Then add `yazi` to `POWERLEVEL9K_LEFT_PROMPT_ELEMENTS` or
+`POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS`, near the top of ~/.p10k.zsh, and open a
+new shell. You can modify the color by editing $ZDOTDIR/.yazi_p10k.zsh
 
 </details>
 
-## Fish
+### Fish
+
 <details>
-<summary>Default prompt</summary>
+  <summary>Default prompt</summary>
 
-It's a bit trickier to apply a general solution to fish. If someone knows a better way of doing this, please open a Pull Request.
+  <details>
+    <summary>Screenshot</summary>
 
-Open a fish shell and execute `funced fish_prompt`. This will open up your text editor. Add the following near the end of the file, inside the fish_prompt function, before any echo or printf calls: 
+![fish](https://github.com/Sonico98/yazi-prompt.sh/assets/61394886/7463296b-74df-48f9-b013-6d8e7c72b131)
 
-```
+  </details>
+It's a bit trickier to apply a general solution to fish. If someone knows a
+better way of doing this, please open a Pull Request.
+
+Open a fish shell and execute `funced fish_prompt`. This will open up your text
+editor. Add the following near the end of the file, inside the fish_prompt
+function, before any echo or printf calls:
+
+```fish
 if test -n "$YAZI_LEVEL"
     set suffix "  Yazi terminal $suffix"
 end
 ```
-Make sure `$suffix` is present in the echo or printf line, save the file and exit your editor. Fish should ask you if you want to save the file, confirm. In case it doesn't, execute `funcsave fish_prompt`.
+
+Make sure `$suffix` is present in the echo or printf line, save the file and exit
+your editor. Fish should ask you if you want to save the file, confirm. In case
+it doesn't, execute `funcsave fish_prompt`.
 
 As an example, this is how the end of the file looks for the default fish prompt:
-```
-    [...]
+
+```fish
     set -l prompt_status (__fish_print_pipestatus "[" "]" "|" "$status_color" "$statusb_color" $last_pipestatus)
     if test -n "$YAZI_LEVEL"
-	set suffix "  Yazi terminal $suffix"
+      set suffix "  Yazi terminal $suffix"
     end
 
     echo -n -s (prompt_login)' ' (set_color $color_cwd) (prompt_pwd) $normal (fish_vcs_prompt) $normal " "$prompt_status $suffix " "
 end
 ```
+
 </details>
 
 <details>
-<summary>Tide</summary>
+  <summary>Tide</summary>
 
-If you use fish  with [tide](https://github.com/IlanCosman/tide) here is a way to end up with a nice prompt:
+  <details>
+    <summary>Screenshot</summary>
 
-- Copy and paste the following into a terminal:
+![tide](https://github.com/Sonico98/yazi-prompt.sh/assets/61394886/96fa8d43-6d00-4dae-a250-300d2dce104f)
+
+  </details>
+
+If you use fish with [tide](https://github.com/IlanCosman/tide) here is a way to
+end up with a nice prompt:
+
+Copy and paste the following into a terminal:
 
 ```sh
 git clone https://github.com/Sonico98/yazi-prompt.sh ./yazi-prompt && \
@@ -98,7 +152,7 @@ cp ./yazi-prompt/fish/tide/_tide_item_yazi.fish  ~/.config/fish/functions/_tide_
 rm -rf ./yazi-prompt
 ```
 
-- Run the following commands to add color to the prompt:
+Run the following commands to add color to the prompt:
 **NOTE**: You can pick whatever colors you are interested in
 
 ```sh
@@ -106,19 +160,29 @@ set --universal tide_yazi_bg_color brblack
 set --universal tide_yazi_color black
 ```
 
-- Add `yazi-prompt` to the tide_left_prompt:
+Add `yazi-prompt` to the tide_left_prompt:
 **NOTE**: Adjust it to your `tide_left_prompt`
 
 ```sh
 set --universal tide_left_prompt_items os yazi context pwd git newline character
 ```
 
-- Reload: `tide reload`
+Reload: `tide reload`
+
 </details>
 
-## Starship
+### Starship
 
 <details>
+  <summary>starship.toml</summary>
+
+  <details>
+    <summary>Screenshot</summary>
+
+![starship](https://github.com/Sonico98/yazi-prompt.sh/assets/61394886/f46a2e45-afec-4672-977b-28ef64065d36)
+
+  </details>
+
 Add a custom module to your `starship.toml`.
 
 ```toml
@@ -141,46 +205,4 @@ $character\
 """
 ```
 
-</details>
-
-
-# Screenshots
-This is what you can expect to see by following the instructions above:
-
-## Bash
-<details>
-<summary>Default prompt</summary>
-
-![bash](https://github.com/Sonico98/yazi-prompt.sh/assets/61394886/05f8c124-c428-4b12-ac04-a4da98bbe06a)
-</details>
-
-## Zsh
-<details>
-<summary>Default prompt</summary>
-
-![zsh](https://github.com/Sonico98/yazi-prompt.sh/assets/61394886/a2f693c7-3c82-4294-ac26-665def2e4a54)
-</details>
-<details>
-<summary>Powerlevel10k</summary>
-
-![p10k](https://github.com/Sonico98/yazi-prompt.sh/assets/61394886/650b977f-d215-4b93-957c-191a4313a897)
-</details>
-
-## Fish
-<details>
-<summary>Default prompt</summary>
-
-![fish](https://github.com/Sonico98/yazi-prompt.sh/assets/61394886/7463296b-74df-48f9-b013-6d8e7c72b131)
-</details>
-<details>
-<summary>Tide</summary>
-
-![tide](https://github.com/Sonico98/yazi-prompt.sh/assets/61394886/96fa8d43-6d00-4dae-a250-300d2dce104f)
-</details>
-
-## Starship
-<details>
-<summary>Example</summary>
-
-![starship](https://github.com/Sonico98/yazi-prompt.sh/assets/61394886/f46a2e45-afec-4672-977b-28ef64065d36)
 </details>

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ it doesn't, execute `funcsave fish_prompt`.
 As an example, this is how the end of the file looks for the default fish prompt:
 
 ```fish
+    [...]
     set -l prompt_status (__fish_print_pipestatus "[" "]" "|" "$status_color" "$statusb_color" $last_pipestatus)
     if test -n "$YAZI_LEVEL"
       set suffix "  Yazi terminal $suffix"


### PR DESCRIPTION
This is a quick reformatting of the readme to improve readability. Screenshots were grouped with their relevant configs and nested in a collapsible element.

See commit message for more details.